### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 120 # Vim
+
+[**.{json,yml,svg}]
+indent_style = space
+indent_size = 2
+
+[{.eslintrc,.stylelintrc}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
From what I've seen:
- *.json, *.yml, *.svg, .eslintrc, .stylelintrc have 2 spaces
- the rest of the files have 4 spaces